### PR TITLE
:construction_worker: Only run workflow when merging into a specific branch (LiveKit)

### DIFF
--- a/.github/workflows/production-build.yaml
+++ b/.github/workflows/production-build.yaml
@@ -1,15 +1,15 @@
 name: production-build
 
 on:
-  push:
-    branches:
-      - 'github-action'
-  pull_request:
+  pull_request_target:
+    types:
+      - closed
     branches:
       - 'livekit'
 
 jobs:
   docker:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       -


### PR DESCRIPTION
Changes the workflow so that it only runs open closing of a pull request to merge into LiveKit.